### PR TITLE
config: implemented basic validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
+	"regexp"
+	"text/template"
 
 	"gopkg.in/yaml.v2"
 )
@@ -24,4 +27,65 @@ func NewConfig(path string) (*config, error) {
 	err = yaml.Unmarshal(yamlFile, c)
 
 	return c, nil
+}
+
+func (c config) ValidateExpressionTemplate() []error {
+	out := []error{}
+	tmpl, err := template.New("expression").Parse(c.Singularity.ExpressionTemplate)
+	if err != nil {
+		out = append(out, err)
+		return out
+	}
+
+	re, err := regexp.Compile(c.Singularity.Expression)
+	if err != nil {
+		out = append(out, err)
+		return out
+	}
+
+	for name, alterverse := range c.Alterverses {
+		for k, _ := range alterverse {
+			var expression bytes.Buffer
+			err = tmpl.Execute(&expression, k)
+			if err != nil {
+				err = fmt.Errorf("Error occured while executing expression template for key '%s' in alterverse '%s': %s", k, name, err.Error())
+				out = append(out, err)
+				continue
+			}
+
+			sm := re.FindAllSubmatch(expression.Bytes(), -1)
+			if len(sm) > 1 {
+				err := fmt.Errorf("Expression '%s' matches more than one time with generated place holder '%s' for key '%s' in alterverse '%s'", c.Singularity.Expression, expression.String(), k, name)
+				out = append(out, err)
+				continue
+			}
+			if len(sm) < 1 {
+				err := fmt.Errorf("Expression '%s' does not match with generated place holder '%s' for key '%s' in alterverse '%s'", c.Singularity.Expression, expression.String(), k, name)
+				out = append(out, err)
+				continue
+			}
+			if len(sm[0]) < 2 {
+				err := fmt.Errorf("Expression '%s' seems not to contain the required match group for key '%s' in alterverse '%s'", c.Singularity.Expression, k, name)
+				out = append(out, err)
+				continue
+			}
+			if len(sm[0]) > 2 {
+				err := fmt.Errorf("Expression '%s' seems to have more than one match group for key '%s' in alterverse '%s'", c.Singularity.Expression, k, name)
+				out = append(out, err)
+				continue
+			}
+			if string(sm[0][0]) != expression.String() {
+				err := fmt.Errorf("Expression '%s' seems to match only a substring of generated place holder '%s' key '%s' in alterverse '%s'", c.Singularity.Expression, expression.String(), k, name)
+				out = append(out, err)
+				continue
+			}
+			if string(sm[0][1]) != k {
+				err := fmt.Errorf("The match group of expression '%s' not to match with key '%s' in alterverse '%s'", k, name)
+				out = append(out, err)
+				continue
+			}
+		}
+	}
+
+	return out
 }

--- a/config.go
+++ b/config.go
@@ -21,14 +21,14 @@ type config struct {
 func NewConfig(path string) (c *config, valErrs []error, err error) {
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {
-		err = fmt.Errorf("Error while reading config file %s: %s\n", path, err)
+		err = fmt.Errorf("Error while reading config file %s: %s", path, err)
 		return
 	}
 
 	c = &config{}
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
-		err = fmt.Errorf("Error while unbarshalling config file %s: %s\n", path, err)
+		err = fmt.Errorf("Error while unbarshalling config file %s: %s", path, err)
 		return
 	}
 

--- a/config.go
+++ b/config.go
@@ -98,7 +98,7 @@ func (c config) ValidateExpressionTemplate() []error {
 				continue
 			}
 			if string(sm[0][1]) != k {
-				err := fmt.Errorf("The match group of expression '%s' not to match with key '%s' in alterverse '%s'", k, name)
+				err := fmt.Errorf("The match group of expression '%s' deos not match with key '%s' in alterverse '%s'", c.Singularity.Expression, k, name)
 				out = append(out, err)
 				continue
 			}

--- a/config.go
+++ b/config.go
@@ -15,18 +15,29 @@ type config struct {
 	Alterverses alterverseConfig `yaml:"alterverses" json:"alterverses"`
 }
 
-func NewConfig(path string) (*config, error) {
+func NewConfig(path string) (*config, error, []error) {
 	c := &config{}
 
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {
-		errOut := fmt.Errorf("Error while reading config file %s: %s\n", path, err)
-		return c, errOut
+		err = fmt.Errorf("Error while reading config file %s: %s\n", path, err)
+		return c, err, []error{}
 	}
 
 	err = yaml.Unmarshal(yamlFile, c)
+	if err != nil {
+		err = fmt.Errorf("Error while unbarshalling config file %s: %s\n", path, err)
+		return c, err, []error{}
+	}
 
-	return c, nil
+	errs := c.Validate()
+	return c, nil, errs
+}
+
+func (c config) Validate() []error {
+	errs := []error{}
+	errs = append(errs, c.ValidateExpressionTemplate()...)
+	return errs
 }
 
 func (c config) ValidateExpressionTemplate() []error {

--- a/config.go
+++ b/config.go
@@ -15,31 +15,38 @@ type config struct {
 	Alterverses alterverseConfig `yaml:"alterverses" json:"alterverses"`
 }
 
-func NewConfig(path string) (*config, error, []error) {
-	c := &config{}
-
+// NewConfig read the given yaml file and returns a config struct. It returns also
+// a slice of valiation errors (which should cause the program to quit) as well as
+// the file operation or parsing error if applicable.
+func NewConfig(path string) (c *config, valErrs []error, err error) {
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {
 		err = fmt.Errorf("Error while reading config file %s: %s\n", path, err)
-		return c, err, []error{}
+		return
 	}
 
+	c = &config{}
 	err = yaml.Unmarshal(yamlFile, c)
 	if err != nil {
 		err = fmt.Errorf("Error while unbarshalling config file %s: %s\n", path, err)
-		return c, err, []error{}
+		return
 	}
 
-	errs := c.Validate()
-	return c, nil, errs
+	valErrs = c.Validate()
+	return
 }
 
+// Validate runs all various Validation tests and returns a slice of all errors
+// found.
 func (c config) Validate() []error {
 	errs := []error{}
 	errs = append(errs, c.ValidateExpressionTemplate()...)
 	return errs
 }
 
+// ValidateExpressionTemplate tests the 'expression' and the 'expression_template'
+// given in the sigularity on order to ensure that the conversion from a alterverse
+// to the singularity and vice versa delievers consistent results
 func (c config) ValidateExpressionTemplate() []error {
 	out := []error{}
 	tmpl, err := template.New("expression").Parse(c.Singularity.ExpressionTemplate)

--- a/config_test.go
+++ b/config_test.go
@@ -27,9 +27,6 @@ func TestExpressionValidation(t *testing.T) {
 		// the key is dublicated in the rendered template
 		{`\<\<\W*([a-zA-Z0-9_])+\W*\>\>`, "<< {{.}}{{.}} >>", "test", true},
 
-		// the key is dublicated in the rendered template
-		{`\<\<\W*([a-zA-Z0-9_])+\W*\>\>`, "<< {{.}}foo >>", "test", true},
-
 		// the template contains too characters in addition to the string
 		// that matches the expression
 		{`\<\<\W*([a-zA-Z0-9_]+)\W*\>\>`, "<< {{.}} >>__", "test", true},

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpressionValidation(t *testing.T) {
+	tests := []struct {
+		expression         string
+		expressionTemplate string
+		definitionKey      string
+		expectErr          bool
+	}{
+		// everything as it should
+		{`\<\<\W*([a-zA-Z0-9_]+)\W*\>\>`, "<< {{.}} >>", "test", false},
+
+		// the template is broken
+		{`\<\<\W*([a-zA-Z0-9_]+)\W*\>\>`, "<< {{.} >>", "test", true},
+
+		// the expression is broken
+		{`\<\<\W*([a-zA-Z0-9_]+\W*\>\>`, "<< {{.}} >>", "test", true},
+
+		// the rendered template results in multiple matches
+		{`\<\<\W*([a-zA-Z0-9_])+\W*\>\>`, "<< {{.}} >><< {{.}} >>", "test", true},
+
+		// the key is dublicated in the rendered template
+		{`\<\<\W*([a-zA-Z0-9_])+\W*\>\>`, "<< {{.}}{{.}} >>", "test", true},
+
+		// the key is dublicated in the rendered template
+		{`\<\<\W*([a-zA-Z0-9_])+\W*\>\>`, "<< {{.}}foo >>", "test", true},
+
+		// the template contains too characters in addition to the string
+		// that matches the expression
+		{`\<\<\W*([a-zA-Z0-9_]+)\W*\>\>`, "<< {{.}} >>__", "test", true},
+
+		// the expression does not contain the required match group
+		{`\<\<\W*[a-zA-Z0-9_]+\W*\>\>`, "<< {{.}} >>", "test", true},
+
+		// the expression does not contains more than one match group
+		{`\<\<\W*([a-zA-Z0-9_]+)(\[a-zA-Z0-9_]+)\W*\>\>`, "<< {{.}} >>", "test", true},
+
+		// the match group does not match the key
+		{`\<\<\W*([A-Z0-9_]+)\W*\>\>`, "<< {{.}} >>", "test", true},
+	}
+
+	for _, test := range tests {
+		c := config{
+			Singularity: singularity{
+				Expression:         test.expression,
+				ExpressionTemplate: test.expressionTemplate,
+			},
+			Alterverses: map[string]map[string]string{
+				"test": map[string]string{
+					test.definitionKey: "does_not_matter",
+				},
+			},
+		}
+
+		errs := c.ValidateExpressionTemplate()
+		hasErr := len(errs) > 0
+		if test.expectErr && !hasErr {
+			t.Errorf("An error was expected for expression '%s' and template '%s' with key '%s', but validation was ok", test.expression, test.expressionTemplate, test.definitionKey)
+		} else if !test.expectErr && hasErr {
+			errStrings := []string{}
+			for _, err := range errs {
+				errStrings = append(errStrings, err.Error())
+			}
+			t.Errorf("No error expected for expression '%s' and template '%s' with key '%s', but validation returned errors: %v", test.expression, test.expressionTemplate, test.definitionKey, strings.Join(errStrings, " AND "))
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,8 +58,8 @@ var createAlterverseCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		l := NewLogger()
 
-		cfg, err, validatienErrs := NewConfig(rootConfigPath)
-		exitOnErr(validatienErrs...)
+		cfg, valErrs, err := NewConfig(rootConfigPath)
+		exitOnErr(valErrs...)
 		exitOnErr(err)
 
 		s := &cfg.Singularity
@@ -98,8 +98,8 @@ var listSingularityKeysCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		l := NewLogger()
 
-		cfg, err, validatienErrs := NewConfig(rootConfigPath)
-		exitOnErr(validatienErrs...)
+		cfg, valErrs, err := NewConfig(rootConfigPath)
+		exitOnErr(valErrs...)
 		exitOnErr(err)
 
 		s := &cfg.Singularity
@@ -117,8 +117,8 @@ var printConfigCmd = &cobra.Command{
 	Use:   "print-config",
 	Short: "Print the configuration as parsed by omniverse",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err, validatienErrs := NewConfig(rootConfigPath)
-		exitOnErr(validatienErrs...)
+		cfg, valErrs, err := NewConfig(rootConfigPath)
+		exitOnErr(valErrs...)
 		exitOnErr(err)
 
 		b, err := yaml.Marshal(cfg)
@@ -134,9 +134,9 @@ var deduceSingularityCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		l := NewLogger()
 
-		cfg, err, validatienErrs := NewConfig(rootConfigPath)
+		cfg, valErrs, err := NewConfig(rootConfigPath)
 		exitOnErr(err)
-		exitOnErr(validatienErrs...)
+		exitOnErr(valErrs...)
 
 		s := &cfg.Singularity
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func init() {
 
 	rootCmd.AddCommand(printConfigCmd)
 
+	rootCmd.AddCommand(verifyConfigCmd)
+
 	deduceSingularityCmd.Flags().StringVarP(&deduceSingularityAlterverse, "alterverse", "a", "", "name of the source alterverse (required)")
 	deduceSingularityCmd.MarkFlagRequired("alterverse")
 	deduceSingularityCmd.Flags().StringVarP(&deduceSingularitySource, "source", "s", "", "path of the source alterverse (required)")
@@ -125,7 +127,27 @@ var printConfigCmd = &cobra.Command{
 
 		b, err := yaml.Marshal(cfg)
 		exitOnErr(err)
+
 		fmt.Println(string(b))
+	},
+}
+
+var verifyConfigCmd = &cobra.Command{
+	Use:   "verify-config",
+	Short: "verify the configuration as parsed by omniverse",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := NewConfig(rootConfigPath)
+		exitOnErr(err)
+
+		errs := cfg.ValidateExpressionTemplate()
+		for _, err = range errs {
+			fmt.Println(err)
+		}
+		if len(errs) == 0 {
+			fmt.Println("No errors found")
+		} else {
+			os.Exit(-1)
+		}
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -59,8 +59,7 @@ var createAlterverseCmd = &cobra.Command{
 		l := NewLogger()
 
 		cfg, valErrs, err := NewConfig(rootConfigPath)
-		exitOnErr(valErrs...)
-		exitOnErr(err)
+		exitOnErr(append(valErrs, err)...)
 
 		s := &cfg.Singularity
 		err = s.Read(rootSingularityPath, l.Input)
@@ -99,8 +98,7 @@ var listSingularityKeysCmd = &cobra.Command{
 		l := NewLogger()
 
 		cfg, valErrs, err := NewConfig(rootConfigPath)
-		exitOnErr(valErrs...)
-		exitOnErr(err)
+		exitOnErr(append(valErrs, err)...)
 
 		s := &cfg.Singularity
 		err = s.Read(rootSingularityPath, l.Input)
@@ -118,8 +116,7 @@ var printConfigCmd = &cobra.Command{
 	Short: "Print the configuration as parsed by omniverse",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, valErrs, err := NewConfig(rootConfigPath)
-		exitOnErr(valErrs...)
-		exitOnErr(err)
+		exitOnErr(append(valErrs, err)...)
 
 		b, err := yaml.Marshal(cfg)
 		exitOnErr(err)
@@ -135,8 +132,7 @@ var deduceSingularityCmd = &cobra.Command{
 		l := NewLogger()
 
 		cfg, valErrs, err := NewConfig(rootConfigPath)
-		exitOnErr(err)
-		exitOnErr(valErrs...)
+		exitOnErr(append(valErrs, err)...)
 
 		s := &cfg.Singularity
 


### PR DESCRIPTION
This implements the subcommand `verify-config` and checks if ...

* the regexp in `singularity.expression` matches with the rendered results of `singularity.expression_template`
* the keys match the matchgroup defined in `singularity.expression`